### PR TITLE
Remove Search Bar

### DIFF
--- a/assets/data/CHANGELOG.md
+++ b/assets/data/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Notes
 
-- There seems to be a Bug regarding the loss of focus when using the down arrow on android
-keyboards. This issue has been mentioned in
-[TextField doesn't loose focus on Android](https://github.com/flutter/flutter/issues/30954).
-
 ## [Unreleased]
+
+## [0.1.0] - 2023-02-05
 
 ### Changed
 
@@ -20,6 +18,7 @@ keyboards. This issue has been mentioned in
 - Experiences are lazy loaded to reduce lags.
 - New logo.
 - Language drop down does not show underline on mobile.
+- Use `SearchDelegate` instead of own search bar widget.
 
 ## [0.0.1] - 2023-01-18
 
@@ -38,5 +37,6 @@ keyboards. This issue has been mentioned in
 - Blog posts now contain bodyReference instead of body. bodyReference references md file inside the
 `assets/data/blogs/` directory.
 
-[unreleased]: https://github.com/Ronho/personal-website/compare/v0.0.1...HEAD
+[unreleased]: https://github.com/Ronho/personal-website/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Ronho/personal-website/tree/v0.1.0
 [0.0.1]: https://github.com/Ronho/personal-website/tree/v0.0.1

--- a/lib/components/nav_bar.dart
+++ b/lib/components/nav_bar.dart
@@ -4,8 +4,6 @@ import 'package:get/get.dart';
 import 'package:personal_website/components/locale_button.dart';
 import 'package:personal_website/components/mobile_search_delegate.dart';
 import 'package:personal_website/components/nav_button.dart';
-// import 'package:personal_website/components/search_bar.dart';
-// import 'package:personal_website/controller/search.dart';
 import 'package:personal_website/controller/theme.dart';
 import 'package:personal_website/models/blog.dart';
 import 'package:personal_website/models/project.dart';
@@ -19,7 +17,6 @@ class NavBar extends StatelessWidget implements PreferredSizeWidget {
   Size get preferredSize => const Size(double.infinity, 56);
 
   final ThemeController themeController = ThemeController.to;
-  // final SearchController searchController = SearchController.to;
 
   bool isActive(String currentRoute, String checkRoute) {
     return currentRoute == checkRoute;
@@ -46,17 +43,6 @@ class NavBar extends StatelessWidget implements PreferredSizeWidget {
     double width,
     BuildContext context,
   ) {
-    // if (searchIsActivated) {
-    //   return SearchBar(
-    //     onFocusLeft: searchController.toggleSearchBar,
-    //     updateLastSearch: searchController.updateLastSearch,
-    //     search: searchController.search,
-    //     lastSearch: searchController.lastSearch,
-    //     width: width,
-    //     height: 50,
-    //     isSmall: isSmall,
-    //   );
-    // } else
     if (isSmall) {
       return NavButton(
         onClick: () => MobileSearchDelegate.show(context),
@@ -118,23 +104,11 @@ class NavBar extends StatelessWidget implements PreferredSizeWidget {
     final bool isSmall = width < SizeService.smallNavBar;
 
     return Obx(() {
-      // if (searchController.searchBarActivated & isSmall) {
-      //   return SearchBar(
-      //     onFocusLeft: searchController.toggleSearchBar,
-      //     updateLastSearch: searchController.updateLastSearch,
-      //     search: searchController.search,
-      //     lastSearch: searchController.lastSearch,
-      //     width: width,
-      //     height: 50,
-      //     isSmall: isSmall,
-      //   );
-      // } else {
       return AppBar(
         automaticallyImplyLeading: false,
         leading: getLeading(isSmall),
         centerTitle: true,
         title: getTitle(
-          // searchController.searchBarActivated,
           isSmall,
           titleWidth,
           context,

--- a/lib/controller/search.dart
+++ b/lib/controller/search.dart
@@ -8,16 +8,8 @@ import 'package:personal_website/models/search_bar_item.dart';
 class SearchController extends GetxController {
   static SearchController get to => Get.find();
 
-  Rx<bool> _searchBarActivated = false.obs;
-  bool get searchBarActivated => _searchBarActivated.value;
-
   Rx<String> _lastSearch = ''.obs;
   String get lastSearch => _lastSearch.value;
-
-  void toggleSearchBar() {
-    _searchBarActivated.value = !_searchBarActivated.value;
-    update();
-  }
 
   void updateLastSearch(String text) {
     _lastSearch.value = text;


### PR DESCRIPTION
Since the old search bar did not work as expected and the new solution using the `SearchDelegate` does work, everthing related to the former solution can be removed. By that, we ensure clean code. However, the current solution should be used for mobile only in the future, since this view is not appropiate for larger screens.